### PR TITLE
Use classifiers to specify the license.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,9 +13,9 @@ setup(name='softshell',
       author_email='saitosean@ymail.com',
       classifiers=[
         'Development Status :: 3 - Alpha',
+        'License :: OSI Approved :: MIT License',
         'Programming Language :: Python :: 3.6'
       ],
-      license='MIT',
       packages=['softshell'],
       install_requires=[
           "PyYAML>=5.1"


### PR DESCRIPTION
Classifiers are a standard way of specifying a license, and make it easy
for automated tools to properly detect the license of the package.

The "license" field should only be used if the license has no
corresponding Trove classifier.